### PR TITLE
Hide table entries

### DIFF
--- a/public/scripts/planetData.js
+++ b/public/scripts/planetData.js
@@ -4,6 +4,7 @@ const apiData = {
 var planetNames = ["mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"];
 
 var detailContainer = document.getElementById('detail-table');
+var currentPlanetTable;
 
 function getPlanet(planetName){
   const apiUrl = `${apiData.url}${planetName}`
@@ -14,7 +15,7 @@ function getPlanet(planetName){
 }
 
 const generateHtml = (planetJson) => {
-  console.log(planetJson);
+  if (currentPlanetTable != undefined) detailContainer.removeChild(currentPlanetTable);
 
   var body = document.body,
       table  = document.createElement('table'),
@@ -71,7 +72,9 @@ const generateHtml = (planetJson) => {
 
   }
 
-  detailContainer.appendChild(table).toggle();
+  currentPlanetTable = table;
+
+  detailContainer.appendChild(table);
 }
 
 // planetNames.forEach(getPlanet);

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -297,3 +297,33 @@ table {
   left: 0;
   z-index: 3;
 }
+
+table {
+  animation: fadeIn ease 1s;
+  -webkit-animation: fadeIn ease 1s;
+}
+
+@keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+
+@-moz-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+
+@-webkit-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+
+@-o-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+
+@-ms-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}


### PR DESCRIPTION
Only one planet panel will be visible on the page at a time now, instead of having them stack on top of each other when clicking additional planets.  The panels also have a "fade in" animation when clicking on them